### PR TITLE
Add Community Support

### DIFF
--- a/src/DataSource.spec.ts
+++ b/src/DataSource.spec.ts
@@ -19,7 +19,6 @@ describe('SdsDataSource', () => {
     uid: '',
     name: '',
     type: '',
-    access: 'direct',
     url,
     meta: null as any,
     jsonData: {

--- a/src/DataSource.spec.ts
+++ b/src/DataSource.spec.ts
@@ -19,6 +19,7 @@ describe('SdsDataSource', () => {
     uid: '',
     name: '',
     type: '',
+    access: 'direct',
     url,
     meta: null as any,
     jsonData: {
@@ -79,7 +80,7 @@ describe('SdsDataSource', () => {
 
     it('should return the correct URL for OCS communities', () => {
       const datasource = new SdsDataSource(ocsCommSettings, backendSrv as any);
-      expect(datasource.streamsUrl).toEqual('URL/ocs/api/VERSION/tenants/TENANT/search/communities/COMMUNITY/streams');
+      expect(datasource.streamsUrl).toEqual('URL/community/api/VERSION/tenants/TENANT/search/communities/COMMUNITY/streams');
     });
 
     it('should return the correct URL for EDS', () => {
@@ -207,7 +208,7 @@ describe('SdsDataSource', () => {
       };
       const response = datasource.query(options as any);
       expect(backendSrv.datasourceRequest).toHaveBeenCalledWith({
-        url: 'URL/ocs/streampath/data?startIndex=FROM&endIndex=TO',
+        url: 'URL/community/streampath/data?startIndex=FROM&endIndex=TO',
         method: 'GET',
       });
       response.then((r) => {

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -36,7 +36,7 @@ export class SdsDataSource extends DataSourceApi<SdsQuery, SdsDataSourceOptions>
   get streamsUrl() {
     return this.type === SdsDataSourceType.OCS
       ? this.ocsUseCommunity === true
-        ? `${this.proxyUrl}/ocs/api/${this.ocsVersion}/tenants/${this.ocsTenant}/search/communities/${this.ocsCommunity}/streams`
+        ? `${this.proxyUrl}/community/api/${this.ocsVersion}/tenants/${this.ocsTenant}/search/communities/${this.ocsCommunity}/streams`
         : `${this.proxyUrl}/ocs/api/${this.ocsVersion}/tenants/${this.ocsTenant}/namespaces/${this.namespace}/streams`
       : `http://localhost:${this.edsPort}/api/v1/tenants/default/namespaces/${this.namespace}/streams`;
   }
@@ -70,7 +70,7 @@ export class SdsDataSource extends DataSourceApi<SdsQuery, SdsDataSourceOptions>
         const url = new URL(target.streamId);
 
         return this.backendSrv.datasourceRequest({
-          url: `${this.proxyUrl}/ocs${url.pathname}/data?startIndex=${from}&endIndex=${to}`,
+          url: `${this.proxyUrl}/community${url.pathname}/data?startIndex=${from}&endIndex=${to}`,
           method: 'GET',
         });
       } else {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -36,6 +36,24 @@
           "client_secret": "{{.SecureJsonData.ocsSecret}}"
         }
       }
+    },
+    {
+      "path": "community",
+      "url": "{{.JsonData.ocsUrl}}",
+      "headers": [
+        {
+          "name": "community-id",
+          "content": "{{.JsonData.ocsCommunity}}"
+        }
+      ],
+      "tokenAuth": {
+        "url": "{{.JsonData.ocsUrl}}/identity/connect/token",
+        "params": {
+          "grant_type": "client_credentials",
+          "client_id": "{{.JsonData.ocsClient}}",
+          "client_secret": "{{.SecureJsonData.ocsSecret}}"
+        }
+      }
     }
   ],
   "dependencies": {


### PR DESCRIPTION
This PR adds support for Community calls by adding a second route which adds the community-id header with the value specified in the data source. 

The second route specified uses 'community' as identifier to be replaced by the OCS Url since these have to be unique.

Tested by using a Community member tenant to read streams from a Community where streams are shared from another tenant, as well as reading local streams.

Reading Community streams from non-owning Tenant:
<img width="1359" alt="Screen Shot 2021-11-23 at 1 30 06 PM" src="https://user-images.githubusercontent.com/92155840/143024379-c66a8bf0-1bac-4643-bc25-1e3b9d7710de.png">

Reading non-Community streams as usual:
<img width="1369" alt="Screen Shot 2021-11-23 at 1 30 39 PM" src="https://user-images.githubusercontent.com/92155840/143024449-5ea87440-4494-497d-8327-38e311f56d38.png">


